### PR TITLE
Fix ValueError in mar.py caused by NumPy array comparison

### DIFF
--- a/src/util/mar.py
+++ b/src/util/mar.py
@@ -486,7 +486,7 @@ class MAR(object):
         for ind,i in enumerate(id):
             tmp = {key: str(self.body[key][i]) for key in self.body}
             tmp["id"]=str(i)
-            if prob!=[]:
+            if len(prob) > 0:
                 tmp["prob"]=prob[ind]
             result.append(tmp)
         return result


### PR DESCRIPTION
## Summary
This PR fixes a `ValueError` that occurs during the training step when running the application with newer versions of Python/NumPy.

## The Problem
When clicking "Next" after labeling the initial batch of documents, the server crashes with the following error:

```text
ValueError: operands could not be broadcast together with shapes (10,) (0,)
```

This happens in ``src/util/mar.py (line 489)`` because the code compares a NumPy array with an empty list ``(if prob != []:)``. In newer NumPy versions, this element-wise comparison is deprecated or fails when shapes do not match.